### PR TITLE
add move_num update to toggle_move method

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -65,7 +65,7 @@ class Piece < ApplicationRecord
   end
 
   def toggle_move!
-    update(moved: true) if moved?
+    update(moved: true, move_num: move_num = move_num + 1) if moved?
   end
 
   def vertical_move?(x_new, y_new)


### PR DESCRIPTION
Update to the update! method call that includes an incrementing the move_num attribute added to db, so that we can track pawn moves susceptible to capture by en passant. 