### PR TITLE
took pusher variable out of methods

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -113,6 +113,16 @@ $( document ).ready(function(){
   $('.alert-notice').fadeOut(4000);
 });
 
+  // Enable pusher logging - don't include this in production
+  var environment = $('body').data('rails-env');
+  if (environment != 'production') {
+  Pusher.logToConsole = true;
+  }
+
+  var pusher = new Pusher('85619837e880f6d5568c', {
+    encrypted: true
+  });
+
 function appendPieceToSquare(piece) {
   var cssSelector = "#" + piece.x_position + piece.y_position;
   var square = $(cssSelector);
@@ -218,18 +228,7 @@ function getPath() {
 }
 
 function showMove() {
-  // Enable pusher logging - don't include this in production
-  var environment = $('body').data('rails-env');
-  if (environment != 'production') {
-  Pusher.logToConsole = true;
-  }
-
-  var pusher = new Pusher('85619837e880f6d5568c', {
-    encrypted: true
-  });
-
   var number = getPath();
-
   var channel = pusher.subscribe("game-channel-" + number);
   channel.bind('piece-moved', function(data) {
   setBoard();
@@ -237,17 +236,7 @@ function showMove() {
 }
 
 function newPlayer(){
-  var environment = $('body').data('rails-env');
-  if (environment != 'production') {
-    Pusher.logToConsole = true;
-  }
-
-  var pusher = new Pusher('85619837e880f6d5568c', {
-    encrypted: true
-  });
-
   var number = getPath();
-
   var channel = pusher.subscribe("player-channel-" + number);
   channel.bind('new-player', function(data) {
     showNewPlayer();


### PR DESCRIPTION
Based on the following snippet from the Pusher documentation: 

> The connection count on pricing plans indicates the number of simultaneous connections allowed.

> A connection is counted as a WebSocket connection to Pusher. When using the Pusher JavaScript library a new WebSocket connection is created when you create a new Pusher instance.

> var pusher = new Pusher('APP_KEY');

> Channel subscriptions are created over the existing WebSocket connection (known as multiplexing), and do not count towards your connection quota (there is no limit on the number allowed per connection).

I removed the pusher variable from the methods so that a connection is only created once per game#show page. I believe this should significantly reduce our connection numbers per day.